### PR TITLE
[be] 상품 상세 조회 API 구현

### DIFF
--- a/be/carrot/src/main/java/com/example/carrot/global/exception/StatusCode.java
+++ b/be/carrot/src/main/java/com/example/carrot/global/exception/StatusCode.java
@@ -46,7 +46,8 @@ public enum StatusCode {
 	INVALID_PRODUCT_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 상태입니다."),
 
 	// -- [IMAGE] -- //
-	NOT_FOUND_IMAGE(HttpStatus.NOT_FOUND, "해당하는 이미지가 없습니다.");
+	NOT_FOUND_IMAGE(HttpStatus.NOT_FOUND, "해당하는 이미지가 없습니다."),
+	NOT_FOUND_MAIN_IMAGE(HttpStatus.NOT_FOUND, "메인 이미지를 찾을 수 없습니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/be/carrot/src/main/java/com/example/carrot/product/controller/ProductController.java
+++ b/be/carrot/src/main/java/com/example/carrot/product/controller/ProductController.java
@@ -17,6 +17,7 @@ import com.example.carrot.product.dto.request.ModifyProductRequestDto;
 import com.example.carrot.product.dto.request.SaveProductRequestDto;
 import com.example.carrot.product.dto.response.MainPageResponseDto;
 import com.example.carrot.product.dto.response.ModifyProductResponseDto;
+import com.example.carrot.product.dto.response.ReadProductDetailResponseDto;
 import com.example.carrot.product.dto.response.SaveProductResponseDto;
 import com.example.carrot.product.service.ProductService;
 
@@ -55,6 +56,11 @@ public class ProductController {
 	public ApiResponse<SaveProductResponseDto> saveProduct(@RequestBody SaveProductRequestDto saveProductRequestDto,
 		@RequestAttribute Long userId) {
 		return ApiResponse.success(productService.saveProduct(saveProductRequestDto, userId));
+	}
+
+	@GetMapping("/products/{productId}")
+	public ApiResponse<ReadProductDetailResponseDto> getProductDetail(@PathVariable Long productId, @RequestAttribute(required = false) Long userId) {
+		return ApiResponse.success(productService.getProductDetail(productId, userId));
 	}
 
 }

--- a/be/carrot/src/main/java/com/example/carrot/product/controller/ProductController.java
+++ b/be/carrot/src/main/java/com/example/carrot/product/controller/ProductController.java
@@ -62,15 +62,6 @@ public class ProductController {
 	}
 
 	/**
-	 * 상품 등록 API
-	 */
-	@PostMapping("/products")
-	public ApiResponse<SaveProductResponseDto> saveProduct(@RequestBody SaveProductRequestDto saveProductRequestDto,
-		@RequestAttribute Long userId) {
-		return ApiResponse.success(productService.saveProduct(saveProductRequestDto, userId));
-	}
-
-	/**
 	 * 상품 삭제 API
 	 */
 	@DeleteMapping("/products/{productId}")
@@ -90,6 +81,15 @@ public class ProductController {
 		ModifyProductResponseDto modifyProductResponseDto = productService.updateProductStatus(
 			modifyProductStatusRequestDto, userId, productId);
 		return ApiResponse.success(modifyProductResponseDto);
+	}
+
+	/**
+	 * 상품 등록 API
+	 */
+	@PostMapping("/products")
+	public ApiResponse<SaveProductResponseDto> saveProduct(@RequestBody SaveProductRequestDto saveProductRequestDto,
+		@RequestAttribute Long userId) {
+		return ApiResponse.success(productService.saveProduct(saveProductRequestDto, userId));
 	}
 
 	/**

--- a/be/carrot/src/main/java/com/example/carrot/product/dto/response/ProductDetailResponseDto.java
+++ b/be/carrot/src/main/java/com/example/carrot/product/dto/response/ProductDetailResponseDto.java
@@ -1,0 +1,49 @@
+package com.example.carrot.product.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+/**
+ * product
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductDetailResponseDto {
+
+	@JsonProperty("location")
+	private String location;
+	@JsonProperty("status")
+	private String status;
+	@JsonProperty("title")
+	private String title;
+	@JsonProperty("category")
+	private String category;
+	@JsonProperty("createdAt")
+	private LocalDateTime createdAt;
+	@JsonProperty("content")
+	private String content;
+	@JsonProperty("chatCount")
+	private Long chatCount;
+	@JsonProperty("likeCount")
+	private Long likeCount;
+	@JsonProperty("hits")
+	private Long hits;
+	@JsonProperty("price")
+	private Long price;
+	@JsonProperty("isLiked")
+	private boolean isLiked;
+
+	public static ProductDetailResponseDto of(String location, String status, String title, String category,
+		LocalDateTime createdAt,
+		String content, Long chatCount, Long likeCount, Long hits, Long price, boolean isLiked) {
+		return new ProductDetailResponseDto(location, status, title, category, createdAt, content, chatCount, likeCount,
+			hits, price, isLiked);
+	}
+
+}
+
+

--- a/be/carrot/src/main/java/com/example/carrot/product/dto/response/ProductDetailSellerResponseDto.java
+++ b/be/carrot/src/main/java/com/example/carrot/product/dto/response/ProductDetailSellerResponseDto.java
@@ -1,0 +1,24 @@
+package com.example.carrot.product.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+/**
+ * seller
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductDetailSellerResponseDto {
+
+	@JsonProperty("id")
+	private Long id;
+	@JsonProperty("nickname")
+	private String nickname;
+
+	public static ProductDetailSellerResponseDto of(Long id, String nickname) {
+		return new ProductDetailSellerResponseDto(id, nickname);
+	}
+
+}

--- a/be/carrot/src/main/java/com/example/carrot/product/dto/response/ProductsResponseDto.java
+++ b/be/carrot/src/main/java/com/example/carrot/product/dto/response/ProductsResponseDto.java
@@ -32,7 +32,7 @@ public class ProductsResponseDto {
 		this.location = location;
 		this.createdAt = createdAt;
 		this.price = price;
-		this.status = status.getName();
+		this.status = status.getValue();
 		this.chatCount = 0L; // chatroom이 erd에 추가되면 수정해야 함
 		this.likeCount = likeCount;
 	}

--- a/be/carrot/src/main/java/com/example/carrot/product/dto/response/ReadProductDetailResponseDto.java
+++ b/be/carrot/src/main/java/com/example/carrot/product/dto/response/ReadProductDetailResponseDto.java
@@ -1,0 +1,26 @@
+package com.example.carrot.product.dto.response;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReadProductDetailResponseDto {
+
+	@JsonProperty("imageUrls")
+	private List<String> imageUrls;
+	@JsonProperty("seller")
+	private ProductDetailSellerResponseDto seller;
+	@JsonProperty("product")
+	private ProductDetailResponseDto product;
+
+	public static ReadProductDetailResponseDto of(List<String> imageUrls, ProductDetailSellerResponseDto seller,
+		ProductDetailResponseDto product) {
+		return new ReadProductDetailResponseDto(imageUrls, seller, product);
+	}
+
+}

--- a/be/carrot/src/main/java/com/example/carrot/product/entity/Product.java
+++ b/be/carrot/src/main/java/com/example/carrot/product/entity/Product.java
@@ -1,5 +1,8 @@
 package com.example.carrot.product.entity;
 
+import static java.time.LocalDateTime.*;
+
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -65,6 +68,9 @@ public class Product extends BaseAllTimeEntity {
 	@JoinColumn(name = "location_id")
 	private Location location;
 
+	@JoinColumn(name = "created_at")
+	private LocalDateTime createdAt;
+
 	@OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Like> likes = new ArrayList<>();
 
@@ -73,7 +79,7 @@ public class Product extends BaseAllTimeEntity {
 
 	@Builder
 	public Product(String name, Long price, String content, Long hits, ProductStatus status, User user,
-		Category category, Location location) {
+		Category category, Location location, LocalDateTime createdAt) {
 		this.name = name;
 		this.price = price;
 		this.content = content;
@@ -82,6 +88,7 @@ public class Product extends BaseAllTimeEntity {
 		this.user = user;
 		this.category = category;
 		this.location = location;
+		this.createdAt = now();
 	}
 
 	public void validateEditAccess(Long userId) {
@@ -107,6 +114,10 @@ public class Product extends BaseAllTimeEntity {
 	public void addUser(User user) {
 		this.user = user;
 		user.getProducts().add(this);
+	}
+
+	public void increaseHit() {
+		this.hits++;
 	}
 
 }

--- a/be/carrot/src/main/java/com/example/carrot/product/entity/Product.java
+++ b/be/carrot/src/main/java/com/example/carrot/product/entity/Product.java
@@ -55,10 +55,6 @@ public class Product extends BaseAllTimeEntity {
 	@Enumerated(EnumType.STRING)
 	private ProductStatus status;
 
-	// TODO: 얘를 추가하면서 이상해짐..
-	@Column(table = "product", name = "created_at")
-	private LocalDateTime createdAt;
-
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
 	private User user;
@@ -79,7 +75,7 @@ public class Product extends BaseAllTimeEntity {
 
 	@Builder
 	public Product(String name, Long price, String content, Long hits, ProductStatus status, User user,
-		Category category, Location location, LocalDateTime createdAt) {
+		Category category, Location location) {
 		this.name = name;
 		this.price = price;
 		this.content = content;
@@ -88,7 +84,6 @@ public class Product extends BaseAllTimeEntity {
 		this.user = user;
 		this.category = category;
 		this.location = location;
-		this.createdAt = createdAt;
 	}
 
 	public void validateEditAccess(Long userId) {

--- a/be/carrot/src/main/java/com/example/carrot/product/entity/Product.java
+++ b/be/carrot/src/main/java/com/example/carrot/product/entity/Product.java
@@ -1,7 +1,5 @@
 package com.example.carrot.product.entity;
 
-import static java.time.LocalDateTime.*;
-
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -13,14 +11,11 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
-
-import org.hibernate.annotations.CreationTimestamp;
 
 import com.example.carrot.category.entity.Category;
 import com.example.carrot.global.common.BaseAllTimeEntity;
@@ -46,6 +41,7 @@ public class Product extends BaseAllTimeEntity {
 
 	@Column(nullable = false)
 	private String name;
+
 	private Long price;
 
 	@Column(length = 500)
@@ -58,6 +54,10 @@ public class Product extends BaseAllTimeEntity {
 	@Enumerated(EnumType.STRING)
 	private ProductStatus status;
 
+	// TODO: 얘를 추가하면서 이상해짐..
+	@Column(table = "product", name = "created_at")
+	private LocalDateTime createdAt;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
 	private User user;
@@ -69,10 +69,6 @@ public class Product extends BaseAllTimeEntity {
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "location_id")
 	private Location location;
-
-	// TODO: JoinColumn()을 하기 전까지는 db에서 잘 생성해주는데, 이걸 해준 후부터는 계속 null이 들어감
-	@JoinColumn(name = "created_at")
-	private LocalDateTime createdAt;
 
 	@OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Like> likes = new ArrayList<>();

--- a/be/carrot/src/main/java/com/example/carrot/product/entity/Product.java
+++ b/be/carrot/src/main/java/com/example/carrot/product/entity/Product.java
@@ -20,6 +20,8 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 
+import org.hibernate.annotations.CreationTimestamp;
+
 import com.example.carrot.category.entity.Category;
 import com.example.carrot.global.common.BaseAllTimeEntity;
 import com.example.carrot.global.exception.CustomException;
@@ -68,6 +70,7 @@ public class Product extends BaseAllTimeEntity {
 	@JoinColumn(name = "location_id")
 	private Location location;
 
+	// TODO: JoinColumn()을 하기 전까지는 db에서 잘 생성해주는데, 이걸 해준 후부터는 계속 null이 들어감
 	@JoinColumn(name = "created_at")
 	private LocalDateTime createdAt;
 
@@ -88,7 +91,7 @@ public class Product extends BaseAllTimeEntity {
 		this.user = user;
 		this.category = category;
 		this.location = location;
-		this.createdAt = now();
+		this.createdAt = createdAt;
 	}
 
 	public void validateEditAccess(Long userId) {

--- a/be/carrot/src/main/java/com/example/carrot/product/entity/ProductStatus.java
+++ b/be/carrot/src/main/java/com/example/carrot/product/entity/ProductStatus.java
@@ -3,16 +3,16 @@ package com.example.carrot.product.entity;
 public enum ProductStatus {
 	ON_SALE, SOLD_OUT, RESERVED;
 
-	public static ProductStatus chooseStatus(final String statusString) {
-		if (statusString.equalsIgnoreCase("RESERVED")) {
-			return ProductStatus.RESERVED;
+	public static String chooseString(ProductStatus status) {
+		if (status == RESERVED) {
+			return "예약중";
 		}
 
-		if (statusString.equalsIgnoreCase("SOLD_OUT")) {
-			return ProductStatus.SOLD_OUT;
+		if (status == SOLD_OUT) {
+			return "판매 완료";
 		}
 
-		return ProductStatus.ON_SALE;
+		return "판매중";
 	}
 
 	public String getName() {

--- a/be/carrot/src/main/java/com/example/carrot/product/entity/ProductStatus.java
+++ b/be/carrot/src/main/java/com/example/carrot/product/entity/ProductStatus.java
@@ -1,5 +1,8 @@
 package com.example.carrot.product.entity;
 
+import com.example.carrot.global.exception.CustomException;
+import com.example.carrot.global.exception.StatusCode;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -12,19 +15,13 @@ public enum ProductStatus {
 
 	private String value;
 
-	public static String chooseString(ProductStatus status) {
-		if (status == RESERVED) {
-			return RESERVED.value;
+	public static ProductStatus chooseStatus(final String statusString) {
+		for (ProductStatus status : ProductStatus.values()) {
+			if (status.getValue().equalsIgnoreCase(statusString)) {
+				return status;
+			}
 		}
-
-		if (status == SOLD_OUT) {
-			return SOLD_OUT.value;
-		}
-
-		return ON_SALE.value;
+		throw new CustomException(StatusCode.INVALID_PRODUCT_STATUS);
 	}
 
-	public String getName() {
-		return this.name();
-	}
 }

--- a/be/carrot/src/main/java/com/example/carrot/product/entity/ProductStatus.java
+++ b/be/carrot/src/main/java/com/example/carrot/product/entity/ProductStatus.java
@@ -9,7 +9,7 @@ public enum ProductStatus {
 		}
 
 		if (status == SOLD_OUT) {
-			return "판매 완료";
+			return "판매완료";
 		}
 
 		return "판매중";

--- a/be/carrot/src/main/java/com/example/carrot/product/service/ProductService.java
+++ b/be/carrot/src/main/java/com/example/carrot/product/service/ProductService.java
@@ -1,7 +1,10 @@
 package com.example.carrot.product.service;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -13,13 +16,17 @@ import com.example.carrot.global.exception.CustomException;
 import com.example.carrot.global.exception.StatusCode;
 import com.example.carrot.image.entity.Image;
 import com.example.carrot.image.repository.ImageRepository;
+import com.example.carrot.like.entity.Like;
 import com.example.carrot.location.entity.Location;
 import com.example.carrot.location.repository.LocationRepository;
 import com.example.carrot.product.dto.request.ModifyProductRequestDto;
 import com.example.carrot.product.dto.request.SaveProductRequestDto;
 import com.example.carrot.product.dto.response.MainPageResponseDto;
 import com.example.carrot.product.dto.response.ModifyProductResponseDto;
+import com.example.carrot.product.dto.response.ProductDetailResponseDto;
+import com.example.carrot.product.dto.response.ProductDetailSellerResponseDto;
 import com.example.carrot.product.dto.response.ProductsResponseDto;
+import com.example.carrot.product.dto.response.ReadProductDetailResponseDto;
 import com.example.carrot.product.dto.response.SaveProductResponseDto;
 import com.example.carrot.product.entity.Product;
 import com.example.carrot.product.entity.ProductStatus;
@@ -154,4 +161,64 @@ public class ProductService {
 
 		return SaveProductResponseDto.of(product.getProductId());
 	}
+
+	public ReadProductDetailResponseDto getProductDetail(Long productId, Long userId) {
+		Product product = getProduct(productId);
+		return ReadProductDetailResponseDto.of(makeImageUrls(product),
+			makeSeller(product), makeProduct(product, userId));
+	}
+
+	private List<String> makeImageUrls(Product product) {
+		// ProductImage의 List 형태가 가장 첫번째로 오는 것이
+		// 이미 대표 이미지의 것이라는 보장이 있어야 함 (이미지 API에서 그렇게 만들어야 함)
+		List<ProductImage> productImages = product.getProductImages();
+		return productImages.stream()
+			.map(productImage -> productImage.getImage().getImageUrl())
+			.collect(Collectors.toUnmodifiableList());
+	}
+
+	private ProductDetailSellerResponseDto makeSeller(Product product) {
+		User user = product.getUser();
+		return ProductDetailSellerResponseDto.of(user.getUserId(), user.getNickName());
+	}
+
+	private ProductDetailResponseDto makeProduct(Product product, Long userId) {
+		String location = product.getLocation().getName();
+
+		String status = ProductStatus.chooseString(product.getStatus());
+		String title = product.getName();
+		String category = product.getCategory().getName();
+		Long price = product.getPrice();
+		String content = product.getContent();
+		LocalDateTime createdAt = product.getCreatedAt();
+
+		// TODO: 채팅 기능 완료 후 추가
+		Long chatCount = 0L;
+
+		// 상품 조회할 때마다 조회수 1 증가
+		product.increaseHit();
+		Long hits = product.getHits();
+
+		List<Like> likes = product.getLikes();
+		Long likeCount = (long)likes.size();
+
+		boolean isLiked = false;
+		if (userId != null) {
+			isLiked = findIsLiked(likes, findUser(userId));
+		}
+
+		return ProductDetailResponseDto.of(location, status, title, category,
+			createdAt, content, chatCount, likeCount, hits, price, isLiked);
+	}
+
+	private User findUser(Long userId) {
+		return userRepository.findById(userId)
+			.orElseThrow(() -> new CustomException(StatusCode.NOT_FOUND_USER));
+	}
+
+	private boolean findIsLiked(List<Like> likes, User user) {
+		return likes.stream()
+			.anyMatch(like -> Objects.equals(like.getUser().getUserId(), user.getUserId()));
+	}
+
 }


### PR DESCRIPTION
## Description

<img width="865" alt="스크린샷 2023-09-11 오후 6 29 43" src="https://github.com/masters2023-4th-project-carrot-talk/carrot-talk-be-a/assets/62871026/6f8d2f03-cb1e-41c6-8a8c-7e570a1a3e1f">

- 정상적으로 응답합니다!
- 주석으로 써놓았긴 했지만 Product 엔티티에 있는 List<ProductImage>의 첫번째 원소가 대표 사진이라는 전제 하에 코드를 작성하였습니다. 이는 이미지 업로드에서 적용할 예정입니다.
- created_at를 가져올 방법이 없어서 Product 엔티티에 추가하였습니다.
  - JoinColumn()을 하기 전까지는 db에서 잘 생성해주는데, 이걸 해준 후부터는 계속 null이 들어가는 버그가 있습니다

## Next Step

- 이미지 업로드 API
